### PR TITLE
Have a visualiser in these trying times

### DIFF
--- a/src/au/edu/qut/prom/visualisers/SLPNVisualiserPlugins.java
+++ b/src/au/edu/qut/prom/visualisers/SLPNVisualiserPlugins.java
@@ -1,0 +1,43 @@
+package au.edu.qut.prom.visualisers;
+
+import javax.swing.JComponent;
+
+import org.processmining.contexts.uitopia.annotations.UITopiaVariant;
+import org.processmining.contexts.uitopia.annotations.Visualizer;
+import org.processmining.framework.plugin.PluginContext;
+import org.processmining.framework.plugin.ProMCanceller;
+import org.processmining.framework.plugin.annotations.Plugin;
+import org.processmining.framework.plugin.annotations.PluginLevel;
+import org.processmining.framework.plugin.annotations.PluginVariant;
+import org.processmining.models.graphbased.directed.petrinet.StochasticNet;
+
+import au.edu.qut.prom.visualisers.dot.SLPNDotVisualiser;
+
+public class SLPNVisualiserPlugins {
+	
+	private SLPNVisualiserPlugins() {};
+	
+	@Plugin(name = ""
+			+ "(Prettier) Stochastic labelled Petri net (simple weights) "
+			+ "visualisation",
+			returnLabels = {"(Prettier) Dot visualization" },
+			returnTypes = { JComponent.class }, 
+			parameterLabels = { "stochastic labelled Petri net", "canceller" },
+			userAccessible = true, level = PluginLevel.NightlyBuild
+			)
+	@Visualizer
+	@UITopiaVariant(
+		affiliation = "qut", 
+		author = "Adam Banham", 
+		email = "adam_banham@hotmail.com")
+	@PluginVariant(
+			variantLabel = ""
+					+ "(Prettier) Stochastic labelled Petri net "
+					+ "visualisation",
+			requiredParameterLabels = { 0, 1 })
+	public static final JComponent visualise(final PluginContext context, 
+			StochasticNet net, ProMCanceller canceller) {
+	return SLPNDotVisualiser.visualise(net);
+	}
+
+}

--- a/src/au/edu/qut/prom/visualisers/SLPNVisualiserPlugins.java
+++ b/src/au/edu/qut/prom/visualisers/SLPNVisualiserPlugins.java
@@ -27,7 +27,7 @@ public class SLPNVisualiserPlugins {
 			)
 	@Visualizer
 	@UITopiaVariant(
-		affiliation = "qut", 
+		affiliation = "QUT", 
 		author = "Adam Banham", 
 		email = "adam_banham@hotmail.com")
 	@PluginVariant(

--- a/src/au/edu/qut/prom/visualisers/dot/SLPNDotVisualiser.java
+++ b/src/au/edu/qut/prom/visualisers/dot/SLPNDotVisualiser.java
@@ -1,0 +1,160 @@
+package au.edu.qut.prom.visualisers.dot;
+
+import org.processmining.plugins.graphviz.dot.Dot;
+import org.processmining.plugins.graphviz.dot.DotNode;
+import org.processmining.plugins.graphviz.visualisation.DotPanel;
+
+import au.edu.qut.prom.helpers.StochasticPetriNetUtils;
+import gnu.trove.map.TIntObjectMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
+
+import org.hamcrest.core.IsInstanceOf;
+import org.processmining.models.graphbased.directed.petrinet.Petrinet;
+import org.processmining.models.graphbased.directed.petrinet.PetrinetEdge;
+import org.processmining.models.graphbased.directed.petrinet.PetrinetNode;
+import org.processmining.models.graphbased.directed.petrinet.StochasticNet;
+import org.processmining.models.graphbased.directed.petrinet.elements.Place;
+import org.processmining.models.graphbased.directed.petrinet.elements.TimedTransition;
+import org.processmining.models.graphbased.directed.petrinet.elements.Transition;
+import org.processmining.models.semantics.petrinet.Marking;
+
+public class SLPNDotVisualiser {
+	
+	private SLPNDotVisualiser() {};
+	
+	public static final String PlaceFill = "#f2f2f2";
+	public static final String StartingPlaceFill = "#80ff00";
+	public static final String EndingPlaceFill = "#FF3939";
+	public static final String TransitionFill = "#e9c6af";
+	public static final String TauFill = "#808080";
+	public static final String WeightFill = "#c0bbbb";
+	
+	public static final DotPanel visualise(StochasticNet net) {
+		Dot dot = new Dot();
+
+		dot.setOption("forcelabels", "true");
+		dot.setOption("bgcolor", "none");
+
+		TIntObjectMap<DotNode> place2dotNode = new TIntObjectHashMap<>(10, 0.5f, -1);
+		
+		Marking marking = StochasticPetriNetUtils.guessInitialMarking((Petrinet) net);
+		
+		for (Place place: net.getPlaces()) {
+			DotNode dotNode = dot.addNode("");
+			dotNode.setOption("shape", "circle");
+			dotNode.setOption("style", "filled");
+			dotNode.setOption("fillcolor", PlaceFill);
+			place2dotNode.put(place.getId().hashCode(), dotNode);
+
+			if (marking.contains(place)) {
+				dotNode.setOption("fillcolor", StartingPlaceFill);
+			}
+			
+			if (net.getOutEdges(place).size() == 0){
+				dotNode.setOption("fillcolor", EndingPlaceFill);
+			}
+
+			decoratePlace(net, place, dotNode);
+		}
+		
+		int tau = 0;
+		for (Transition trans: net.getTransitions()) {
+			DotNode dotNode;
+			TimedTransition ttrans = null;
+			if (trans instanceof TimedTransition) {
+				ttrans = (TimedTransition) trans;
+			}
+			if (trans.isInvisible()) {
+				tau+= 1;
+				dotNode = dot.addNode("<"
+						+ "<TABLE"
+						+ " BORDER=\"0\" "
+						+ "><TR>"
+						+ "<TD><FONT POINT-SIZE=\"16\" >"
+						+ "&#120591;"
+						+ "</FONT>"
+						+ "<FONT POINT-SIZE=\"10\">(" 
+						+ tau 
+						+")</FONT></TD>"
+						+ "</TR>"
+						+ "<TR>"
+						+ "<TD ALIGN=\"LEFT\">"
+						+ "<FONT ALIGN=\"LEFT\" POINT-SIZE=\"10\" >"
+						+ "<I>weight:</I>"
+						+ "</FONT>"
+						+ "</TD>"
+						+ "</TR>"
+						+ "<TR>"
+						+ "<TD BORDER=\"1\" BGCOLOR=\"#c0bbbb\" "
+						+ "STYLE=\"ROUNDED,DASHED\" "
+						+ "CELLPADDING=\"5\" "
+						+ ">"
+						+ ttrans.getWeight()
+						+ "</TD>"
+						+ "</TR>"
+						+ "</TABLE>"
+						+ ">");
+				dotNode.setOption("style", "filled,rounded");
+				dotNode.setOption("fillcolor", TauFill);
+			} else {
+				dotNode = dot.addNode("<"
+						+ "<TABLE"
+						+ " BORDER=\"0\" "
+						+ "><TR>"
+						+ "<TD>" 
+						+ trans.getLabel() 
+						+"</TD>"
+						+ "</TR>"
+						+ "<TR>"
+						+ "<TD ALIGN=\"LEFT\">"
+						+ "<FONT ALIGN=\"LEFT\" POINT-SIZE=\"10\" >"
+						+ "<I>weight:</I>"
+						+ "</FONT>"
+						+ "</TD>"
+						+ "</TR>"
+						+ "<TR>"
+						+ "<TD BORDER=\"1\" BGCOLOR=\"#c0bbbb\" "
+						+ "STYLE=\"ROUNDED,DASHED\" "
+						+ "CELLPADDING=\"5\" "
+						+ ">"
+						+ ttrans.getWeight()
+						+ "</TD>"
+						+ "</TR>"
+						+ "</TABLE>"
+						+ ">");
+				dotNode.setOption("style", "rounded,filled");
+				dotNode.setOption("fillcolor", TransitionFill);
+			}
+
+			dotNode.setOption("shape", "box");
+			dotNode.setOption("width", "1");
+
+			decorateTransition(net, trans, dotNode);
+			
+			for (PetrinetEdge<? extends PetrinetNode, ? extends PetrinetNode> edge: net.getOutEdges(trans)) {
+					Place pplace = (Place) edge.getTarget();
+					dot.addEdge(dotNode, 
+						place2dotNode.get(pplace.getId().hashCode())
+					);
+			}
+			for ( PetrinetEdge<? extends PetrinetNode, ? extends PetrinetNode> edge : net.getInEdges(trans)) {
+					Place pplace = (Place) edge.getSource();
+					dot.addEdge(
+						place2dotNode.get(pplace.getId().hashCode()),
+						dotNode
+					);
+			}
+		}
+
+		return new DotPanel(dot);
+	}
+	
+	public static void decoratePlace(StochasticNet net, Place place, DotNode dotNode) {
+		
+	}
+
+	public static void decorateTransition(StochasticNet net, Transition transition, DotNode dotNode) {
+		
+	}
+
+}


### PR DESCRIPTION
After using the alignment estimator, I found myself coding this possible addition.

This PR adds a `StochasticNet` visualiser using a dot chart. While preparing my thesis, I needed to visualise the outcomes from the estimators and did not like the current options. I also wanted something similar to the visualiser in ExogenousData Package, so rather than throw this away afterwards, please consider the additional of the visualiser to the project.

Using the road fines log and the attached normative model the visualiser produces the following:
![norm_model_road_fines_estalign](https://github.com/promworkbench/StochasticWeightEstimation/assets/38652037/78dd3922-f244-41eb-8741-d443b7d23a55)

Visualiser is named "(Prettier) Stochastic labelled Petri net (simple weights)" and works for `StochasticNet` constructs.


Also as a side note, you may want set the option for the alignments to find the nearest closest activity mapping, rather than an absolute mapping. I had a transition "Add Penalty" but the log only contains "Add penalty", the UI wizard for the mapping usually catches these little slip-ups.